### PR TITLE
Revert "add do_compression option for savemat."

### DIFF
--- a/hdf5storage/__init__.py
+++ b/hdf5storage/__init__.py
@@ -150,9 +150,7 @@ class Options(object):
                  complex_names=('r', 'i'),
                  group_for_references="/#refs#",
                  oned_as='row',
-                 marshaller_collection=None,
-                 scalar_options=dict(),
-                 array_options=dict()):
+                 marshaller_collection=None):
         # Set the defaults.
 
         self._store_python_metadata = True
@@ -192,10 +190,10 @@ class Options(object):
         self.matlab_compatible = matlab_compatible
 
         # Set the h5py options to use for writing scalars and arrays to
-        # input arguments.
+        # blank for now.
 
-        self.scalar_options = scalar_options
-        self.array_options = array_options
+        self.scalar_options = dict()
+        self.array_options = dict()
 
         # Use the given marshaller collection if it was
         # given. Otherwise, use the default.
@@ -1158,8 +1156,7 @@ def savemat(file_name, mdict, appendmat=True, format='7.3',
             oned_as='row', store_python_metadata=True,
             action_for_matlab_incompatible='error',
             marshaller_collection=None, truncate_existing=False,
-            truncate_invalid_matlab=False, do_compression=False,
-            **keywords):
+            truncate_invalid_matlab=False, **keywords):
     """ Save a dictionary of python types to a MATLAB MAT file.
 
     Saves the data provided in the dictionary `mdict` to a MATLAB MAT
@@ -1209,8 +1206,6 @@ def savemat(file_name, mdict, appendmat=True, format='7.3',
         Whether to truncate a file if the file doesn't have the proper
         header (userblock in HDF5 terms) setup for MATLAB metadata to be
         placed.
-    do_compression : bool, optional
-        Whether or not to compress matrices on write.  Default is False.
     **keywords :
         Additional keywords arguments to be passed onto
         ``scipy.io.savemat`` if dispatching to SciPy (`format` < 7.3).
@@ -1256,19 +1251,11 @@ def savemat(file_name, mdict, appendmat=True, format='7.3',
     if appendmat and not file_name.endswith('.mat'):
         file_name = file_name + '.mat'
 
-    # Process compression option
     # Make the options with matlab compatibility forced.
-    if do_compression:
-        options = Options(store_python_metadata=store_python_metadata, \
-            matlab_compatible=True, oned_as=oned_as, \
-            action_for_matlab_incompatible=action_for_matlab_incompatible, \
-            marshaller_collection=marshaller_collection, \
-            array_options={'compression':'gzip'})
-    else:
-        options = Options(store_python_metadata=store_python_metadata, \
-            matlab_compatible=True, oned_as=oned_as, \
-            action_for_matlab_incompatible=action_for_matlab_incompatible, \
-            marshaller_collection=marshaller_collection)
+    options = Options(store_python_metadata=store_python_metadata, \
+        matlab_compatible=True, oned_as=oned_as, \
+        action_for_matlab_incompatible=action_for_matlab_incompatible, \
+        marshaller_collection=marshaller_collection)
 
     # Write the variables in the dictionary to file one at a time. For
     # the first one, the file needs to be truncated or truncated if not


### PR DESCRIPTION
Reverts frejanordsiek/hdf5storage#18

I wrote a full and complete compression implementation to replace this. Just wanted to say that your pull request was good use of an undocumented feature I actually added in there with this sort of use in mind for the future. Going to be implementing it without that feature.