### PR TITLE
s/requires/install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='hdf5storage',
       author_email='fnordsie at gmail dt com',
       url='https://github.com/frejanordsiek/hdf5storage',
       packages=['hdf5storage'],
-      requires=['numpy', 'h5py (>= 2.1)'],
+      install_requires=['numpy', 'h5py (>= 2.1)'],
       license='BSD',
       keywords='hdf5 matlab',
       classifiers=[


### PR DESCRIPTION
The "requires" keyword in modern setuptools is deprecated in favour of "install_requires". This PR does the appropriate substitution.