### PR TITLE
Fix deprecation warning from h5py

### DIFF
--- a/hdf5storage/__init__.py
+++ b/hdf5storage/__init__.py
@@ -1626,7 +1626,7 @@ def writes(mdict, filename='data.h5', truncate_existing=False,
         if truncate_existing or not os.path.isfile(filename):
             f = h5py.File(filename, mode='w', userblock_size=512)
         else:
-            f = h5py.File(filename)
+            f = h5py.File(filename, mode='r+')
             if options.matlab_compatible and truncate_invalid_matlab \
                     and f.userblock_size < 128:
                 f.close()
@@ -1687,7 +1687,7 @@ def writes(mdict, filename='data.h5', truncate_existing=False,
     # can be closed if any errors happen (the error is re-raised).
     f = None
     try:
-        f = h5py.File(filename)
+        f = h5py.File(filename, mode='r+')
 
         # Go through each element of towrite and write them.
         for groupname, targetname, data in towrite:


### PR DESCRIPTION
h5py, from version 3.0, requires to specify a mode when opening a file: https://github.com/h5py/h5py/pull/1143

This fixes that by using 'r+' where nothing was specified so far.